### PR TITLE
Update RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Layout/LineLength:
 Lint/AmbiguousOperator:
   # https://github.com/rubocop/rubocop/issues/4294
   Exclude:
-    - "lib/openai/client.rb"
+    - "lib/rubyai.rb"
 
 Metrics/AbcSize:
   Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,14 @@ Layout/LineLength:
   Exclude:
     - "**/*.gemspec"
 
+Lint/AmbiguousOperator:
+  # https://github.com/rubocop/rubocop/issues/4294
+  Exclude:
+    - "lib/openai/client.rb"
+
+Metrics/AbcSize:
+  Max: 20
+
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"


### PR DESCRIPTION
- [x] Exclude "lib/rubyai.rb" from Lint/AmbiguousOperator checks.
- [x] Set maximum AbcSize metric to 20